### PR TITLE
Properly spell prefer

### DIFF
--- a/pwntools/level-2-4/pwntools-tutorials-level2.4
+++ b/pwntools/level-2-4/pwntools-tutorials-level2.4
@@ -237,7 +237,7 @@ class ASMChallenge(ASMBase):
         In this level you need to craft assembly code to complete the following operations:
         * the top value of the stack = the top value of the stack - rbx
 
-        Tips: perfer push and pop instructions, other than directly [esp] dereference
+        Tips: prefer push and pop instructions, other than directly [esp] dereference
         """
 
     def trace(self):


### PR DESCRIPTION
Fix a typo in the description printed as part of the challenge.
